### PR TITLE
Use user id instead of user in dependency arrays

### DIFF
--- a/src/pages/Announcements.tsx
+++ b/src/pages/Announcements.tsx
@@ -111,13 +111,13 @@ export const Announcements = () => {
 
   // Fetch user profile
   const fetchUserProfile = useCallback(async () => {
-    if (!user) return;
+    if (!user?.id) return;
     
     const userType = await getUserProfileType(user.id);
     if (userType) {
       setUserProfile({ user_type: userType });
     }
-  }, [user.id]);
+  }, [user?.id]);
 
   useEffect(() => {
     fetchUserProfile();
@@ -176,12 +176,12 @@ export const Announcements = () => {
   }, [selectedTag, sortBy, upcomingPagination, pastPagination]);
 
   const handleCreateAnnouncement = useCallback(async (data: unknown) => {
-    if (!user) return;
+    if (!user?.id) return;
 
     log.info('Announcement created successfully');
     setIsModalOpen(false);
     refetch(); // Refresh announcements list
-  }, [user.id, refetch]);
+  }, [user?.id, refetch]);
 
   const canCreateAnnouncement = useMemo(() => 
     canUserCreateAnnouncements(userProfile?.user_type || null),

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -74,10 +74,10 @@ const Auth = () => {
   });
 
   useEffect(() => {
-    if (!loading && user) {
+    if (!loading && user?.id) {
       navigate("/");
     }
-  }, [user.id, loading, navigate]);
+  }, [user?.id, loading, navigate]);
 
   const onLogin = async (data: LoginForm) => {
     setIsSubmitting(true);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -169,16 +169,16 @@ const Dashboard = () => {
 
 
   useEffect(() => {
-    if (!loading && !user) {
+    if (!loading && !user?.id) {
       navigate('/auth');
     }
-  }, [user.id, loading, navigate]);
+  }, [user?.id, loading, navigate]);
 
 
   // Fetch dashboard data, analytics, and tags (consolidated - all have same dependencies)
   useEffect(() => {
     const fetchAllData = async () => {
-      if (!user || !profile) return;
+      if (!user?.id || !profile) return;
       
       try {
         // Set all loading states
@@ -233,7 +233,7 @@ const Dashboard = () => {
     };
 
     fetchAllData();
-  }, [user.id, profile]);
+  }, [user?.id, profile]);
 
   // Calculate statistics with useMemo
   const stats = useMemo(() => {
@@ -307,7 +307,7 @@ const Dashboard = () => {
   // Fetch residency data (separate effect - depends on profiles)
   useEffect(() => {
     const fetchResidencyData = async () => {
-      if (!user || !profile || profiles.length === 0) return;
+      if (!user?.id || !profile || profiles.length === 0) return;
       
       try {
         setResidencyLoading(true);
@@ -326,7 +326,7 @@ const Dashboard = () => {
     };
 
     fetchResidencyData();
-  }, [user.id, profile, profiles]);
+  }, [user?.id, profile, profiles]);
 
   // Residency partner handlers with useCallback
   const handleCreatePartner = useCallback(async () => {

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -99,7 +99,7 @@ const Events = () => {
   });
 
   const fetchUserProfile = useCallback(async () => {
-    if (!user) return;
+    if (!user?.id) return;
     
     try {
       const userType = await getUserProfileType(user.id);
@@ -109,14 +109,14 @@ const Events = () => {
     } catch (err) {
       log.error('Error fetching user profile:', err);
     }
-  }, [user.id]);
+  }, [user?.id]);
 
   useEffect(() => {
     refetchEvents();
-    if (user) {
+    if (user?.id) {
       fetchUserProfile();
     }
-  }, [user.id, fetchUserProfile, refetchEvents]);
+  }, [user?.id, fetchUserProfile, refetchEvents]);
 
   const handleEventCreated = useCallback(() => {
     refetchEvents(); // Refresh events list
@@ -124,8 +124,8 @@ const Events = () => {
 
   // Check if user can create events (admin only) - memoized
   const canCreateEvents = useMemo(() => 
-    user && userProfile && canUserCreateEvents(userProfile.user_type),
-    [user.id, userProfile]
+    user?.id && userProfile && canUserCreateEvents(userProfile.user_type),
+    [user?.id, userProfile]
   );
 
   // Apply tag filter

--- a/src/pages/Gawk.tsx
+++ b/src/pages/Gawk.tsx
@@ -52,7 +52,7 @@ const Gawk = () => {
 
 
   const fetchAnalytics = useCallback(async () => {
-    if (!user || !profile) return;
+    if (!user?.id || !profile) return;
 
     try {
       setAnalyticsLoading(true);
@@ -93,7 +93,7 @@ const Gawk = () => {
       setAnalyticsLoading(false);
       setDataLoading(false);
     }
-  }, [user.id, profile]);
+  }, [user?.id, profile]);
 
   useEffect(() => {
     fetchAnalytics();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -53,7 +53,7 @@ const Index = () => {
 
   // Reset form state when user changes
   useEffect(() => {
-    if (!user) {
+    if (!user?.id) {
       setFormData({
         fullName: '',
         city: '',
@@ -82,13 +82,13 @@ const Index = () => {
       setEditingResidency(null);
       setResidencyLoading(true);
     }
-  }, [user.id]);
+  }, [user?.id]);
 
   useEffect(() => {
-    if (!loading && !user) {
+    if (!loading && !user?.id) {
       navigate('/auth');
     }
-  }, [user.id, loading, navigate]);
+  }, [user?.id, loading, navigate]);
 
     const fetchProfile = useCallback(async () => {
       if (!user || isFetching.current) return;
@@ -132,7 +132,7 @@ const Index = () => {
 
     // Fetch residency data
     const fetchResidencyData = useCallback(async () => {
-      if (!user) return;
+      if (!user?.id) return;
       setResidencyLoading(true);
       try {
         const [userResidencies, partners] = await Promise.all([
@@ -163,7 +163,7 @@ const Index = () => {
    }, [profileLoading]);
 
   const handleAvatarUpload = useCallback(async (file: File) => {
-    if (!user) return null;
+    if (!user?.id) return null;
 
     const publicUrl = await uploadAvatar(user.id, file);
     if (publicUrl) {
@@ -173,7 +173,7 @@ const Index = () => {
   }, [user?.id]);
 
   const handleSaveProfile = useCallback(async () => {
-    if (!user) return;
+    if (!user?.id) return;
     setSaving(true);
     try {
       let avatarUrlToSave = formData.avatarUrl;


### PR DESCRIPTION
Seems like Supabase is refreshing the local auth token when the tab is changed and that's triggering a bunch of refreshes because it's updating the `user` object, which is in a bunch of dependency arrays throughout the app. 

Before:

https://github.com/user-attachments/assets/f1ced550-637b-42f5-8187-f5b4c05117e4

After:

https://github.com/user-attachments/assets/7a3270d3-63c9-41f4-b073-280bae0df505

