### PR TITLE
chore(cicd): use a GitHub app credentials for checkout also

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,8 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PORTAL_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.PORTAL_RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout
-        uses: actions/checkout@v4       
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -52,13 +62,6 @@ jobs:
       - name: Build
         run: pnpm build
         
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.PORTAL_RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.PORTAL_RELEASE_BOT_PRIVATE_KEY }}
-
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Description
Follow on from https://github.com/ise-alumni/portal/pull/104
CD still not working - think I need to use the same cred for the checkout step. 

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Style/formatting changes (no functional changes)
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] Build/config changes


